### PR TITLE
Campaign referral fixed in android native sdk 0.10.5

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
-    implementation "com.github.blotoutio:sdk-android:0.10.4"
+    implementation "com.github.blotoutio:sdk-android:0.10.5"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blotoutio/sdk-react-native",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "homepage": "https://github.com/blotoutio/sdk-react-native",
   "description": "Blotout React Native Library",
   "main": "lib/index.js",


### PR DESCRIPTION
1. Integrated Android blotout sdk version 0.10.5 
2. Version bump to 0.10.7