### PR TITLE
Campaign referral fixed in android native sdk 0.10.5

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
-    implementation "com.github.blotoutio:sdk-android:0.10.4"
+    implementation "com.github.blotoutio:sdk-android:0.10.5"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blotoutio/sdk-react-native",
-  "version": "0.10.6-alpha.0",
+  "version": "0.10.7-alpha.0",
   "homepage": "https://github.com/blotoutio/sdk-react-native",
   "description": "Blotout React Native Library",
   "main": "lib/index.js",


### PR DESCRIPTION
1. Integrate Android Blotout sdk 0.10.5 , that have campaign referral fixed 
2. Version bump. 